### PR TITLE
WIP: Add database support when saving campaigns

### DIFF
--- a/app/api/campaigns/[campaignId]/route.ts
+++ b/app/api/campaigns/[campaignId]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { campaignId: string } }
+) {
+  try {
+    const body = await request.json()
+    const { status, transactionHash, campaignAddress } = body
+
+    const campaign = await prisma.campaign.update({
+      where: {
+        id: parseInt(params.campaignId)
+      },
+      data: {
+        status,
+        transactionHash,
+        campaignAddress
+      },
+    })
+
+    return NextResponse.json(campaign)
+  } catch (error) {
+    console.error('Failed to update campaign:', error)
+    return NextResponse.json(
+      { error: 'Failed to update campaign' },
+      { status: 500 }
+    )
+  }
+} 

--- a/components/campaign-list.tsx
+++ b/components/campaign-list.tsx
@@ -35,6 +35,10 @@ interface Campaign {
   deadline: string;
   goalAmount: string;
   totalRaised: string;
+  title: string;
+  description: string;
+  location: string;
+  imageUrl?: string;
 }
 
 export default function CampaignList() {
@@ -102,15 +106,15 @@ export default function CampaignList() {
         <Card key={campaign.address} className="overflow-hidden hover:shadow-lg transition-shadow">
           <CardHeader className="p-0">
             <Image
-              src='/images/placeholder.svg'
-              alt={campaign.address}
+              src={campaign.imageUrl || '/images/placeholder.svg'}
+              alt={campaign.title || campaign.address}
               width={600}
               height={400}
               className="h-[200px] w-full object-cover"
             />
           </CardHeader>
           <CardContent className="p-6">
-            <h2 className="mb-2 text-xl font-bold">{'Campaign Title'}</h2>
+            <h2 className="mb-2 text-xl font-bold">{campaign.title || 'Campaign Title'}</h2>
             <div className="mb-4 flex items-center gap-2">
               <Image
                 src={`https://avatar.vercel.sh/${campaign.address}`}
@@ -121,10 +125,10 @@ export default function CampaignList() {
               />
               <span className="font-medium">{`${campaign.owner.slice(0, 10)}...` || 'Campaign Author'}</span>
               <span className="text-gray-500">•</span>
-              <span className="text-gray-500">{'Earth'}</span>
+              <span className="text-gray-500">{campaign.location || 'Earth'}</span>
             </div>
             <div className="space-y-2 py-5 ">
-              <p className=" text-gray-600">{'Campaign Description'}</p>
+              <p className="text-gray-600">{campaign.description || 'Campaign Description'}</p>
 
               <p className="text-sm"><strong>Launch:</strong> {formatDate(campaign.launchTime)}</p>
               <p className="text-sm"><strong>Deadline:</strong> {formatDate(campaign.deadline)}</p>


### PR DESCRIPTION
This is still a WIP. 

This inserts the meta data for a campaign into the database, and then pulls it back out again on the api/campaigns route.

We need to update the updateCampaign in useEffect in create-campaign to also update the database with the campaignAddress of we get from the CCP once we have successfully created the campaign.

We then need to match on campaignAddress in order to link the database data to the CCP campaign.

Another what would be to send our unique ID to CCP.....I remember asking what the purpose of the identifier we were sending to CCP before, but didn't see your response. Should we send them a unique Id we use to fetch the metadata from the database? 