### PR TITLE
feat(dev): optimize sentry

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, RefreshCw } from 'lucide-react';
-import * as Sentry from '@sentry/nextjs';
+import { Sentry } from '@/lib/sentry';
 
 export default function ErrorPage({
   error,

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, RefreshCw } from 'lucide-react';
-import * as Sentry from '@sentry/nextjs';
+import { Sentry } from '@/lib/sentry';
 import { useEffect } from 'react';
 
 export default function GlobalError({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,12 +50,12 @@ services:
       context: .
       target: devrunner
     depends_on:
-      database:
-        condition: service_healthy
+      - database
     ports:
       - "${DEV_APP_PORT:-3000}:3000"
     volumes:
       - ./:/app
+      - ./lib/sentry-dev.ts:/app/lib/sentry.ts
       # - ./dev_modules/app/node_modules:/app/node_modules
       - ./dev_modules/app/.next:/app/.next
       - ./dev_modules/pnpm_store:/app/.pnpm-store

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,7 +2,7 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs';
+import { Sentry } from '@/lib/sentry';
 
 if (process.env.SENTRY_DSN) {
   Sentry.init({

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/nextjs';
+import { Sentry } from '@/lib/sentry';
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {

--- a/lib/sentry-dev.ts
+++ b/lib/sentry-dev.ts
@@ -1,0 +1,22 @@
+// this is the mock/development sentry object
+// it avoids about 2k modules in next dev build and speeds
+// up the hot-reloading significantly
+// This file is not imported directly, but bind-mounted by the
+// docker-compose.yml
+let Sentry = {
+  setUser: (any) => {},
+  captureException: (e) => 'mocked-in-development',
+  captureRequestError: (any) => {},
+  getFeedback: () =>
+    undefined as
+      | undefined
+      | {
+          attachTo: (any) => undefined;
+        },
+  addEventProcessor: (any) => any,
+  init: (options: unknown) => {
+    console.log('mocked-sentry-init', options);
+  },
+};
+
+export { Sentry };

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -1,0 +1,6 @@
+// this is the default/production sentry object
+// it adds about 2k modules in next dev build and hurts
+// the developer experience.
+import * as Sentry from '@sentry/nextjs';
+
+export { Sentry };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,4 @@
 import type { NextConfig } from 'next';
-import { withSentryConfig } from '@sentry/nextjs';
 
 const nextConfig: NextConfig = {
   images: {
@@ -27,35 +26,56 @@ const nextConfig: NextConfig = {
     ],
   },
 };
+if (process.env.SENTRY === 'true' || process.env.NODE_ENV === 'production') {
+  console.log(' ▲ sentry initialization');
+  // this import decreases the developer experience in next dev
+  // for that reason it is executed conditionally.
+  // also be aware of the docker-compose bind-mount of
+  // lib/sentry-dev.ts -> lib/sentry.ts which you need to
+  // disable if you want to test/debug sentry in dev-mode
+  const { withSentryConfig } = require('@sentry/nextjs');
 
-export default withSentryConfig(nextConfig, {
-  // For all available options, see:
-  // https://www.npmjs.com/package/@sentry/webpack-plugin#options
+  const sentryConfig = withSentryConfig(nextConfig, {
+    // For all available options, see:
+    // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
-  org: 'akashic-yj',
-  project: 'akashic-app',
+    org: 'akashic-yj',
+    project: 'akashic-app',
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+    // Only print logs for uploading source maps in CI
+    silent: !process.env.CI,
 
-  // For all available options, see:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+    // For all available options, see:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: true,
+    // Upload a larger set of source maps for prettier stack traces (increases build time)
+    widenClientFileUpload: true,
 
-  // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-  // This can increase your server load as well as your hosting bill.
-  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-  // side errors will fail.
-  tunnelRoute: '/monitoring',
+    // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+    // This can increase your server load as well as your hosting bill.
+    // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+    // side errors will fail.
+    tunnelRoute: '/monitoring',
 
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
+    // Automatically tree-shake Sentry logger statements to reduce bundle size
+    disableLogger: true,
 
-  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-  // See the following for more information:
-  // https://docs.sentry.io/product/crons/
-  // https://vercel.com/docs/cron-jobs
-  automaticVercelMonitors: true,
-});
+    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+    // See the following for more information:
+    // https://docs.sentry.io/product/crons/
+    // https://vercel.com/docs/cron-jobs
+    automaticVercelMonitors: true,
+  });
+
+  console.log(' ▲ sentry loading');
+  module.exports = {
+    ...sentryConfig,
+    serverExternalPackages: ['@sentry/profiling-node'],
+    async rewrites() {
+      return await nextConfig.rewrites();
+    },
+  };
+} else {
+  console.log(' ▲ sentry mocked');
+  module.exports = nextConfig;
+}

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,7 +3,7 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs';
+import { Sentry } from '@/lib/sentry';
 
 if (process.env.SENTRY_DSN) {
   Sentry.init({

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,7 +2,7 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs';
+import { Sentry } from '@/lib/sentry';
 
 if (process.env.SENTRY_DSN) {
   Sentry.init({


### PR DESCRIPTION
- in dev mode, avoid loading any sentry modules which speeds up the build-time significantly

- moves all @sentry/nextjs imports to @/lib/sentry
- magic with docker-compose to override @/lib/sentry.ts with a mocked @/lib/sentry-dev.ts
- magic with docker-compose to start app even if db is not ready yet (saves ~5s)
- only load withSentryConfig in next.config if in production

reduces
 - initial build/load from 961 modules to 24 modules, 4.5s to 1.5s
 - initial load of '/' from 3912 modules to 1522 modules, 10.5s to 6.4s

(numbers with all wagmi/ethers/silk disabled as well)