### PR TITLE
feat(donation): refactor donation form

### DIFF
--- a/app/campaigns/[slug]/donation/page.tsx
+++ b/app/campaigns/[slug]/donation/page.tsx
@@ -1,4 +1,4 @@
-import DonationForm from '@/components/donation-form';
+import { CampaignDonationForm } from '@/components/campaign/donation/form';
 import ProjectInfo from '@/components/project-info';
 import { Campaign } from '@/types/campaign';
 import { getCampaign } from '@/lib/database';
@@ -16,7 +16,7 @@ export default async function Page({
     <>
       <PageHeaderSticky message="Donating to" title={campaign.title} />
       <PageMainTwoColums>
-        <DonationForm campaign={campaign} />
+        <CampaignDonationForm campaign={campaign} />
         <ProjectInfo slug={slug} />
       </PageMainTwoColums>
     </>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import localFont from 'next/font/local';
 import './globals.css';
 import Providers from './providers';
 import { Toaster } from '@/components/ui/toaster';
-import { NetworkCheck } from '@/components/network-check';
 import { PageMainLayout } from '@/components/page/main-layout';
 import { EnvironmentBadge } from '@/components/environment-badge';
 
@@ -34,9 +33,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
-          <NetworkCheck>
-            <PageMainLayout>{children}</PageMainLayout>
-          </NetworkCheck>
+          <PageMainLayout>{children}</PageMainLayout>
           <Toaster />
           <EnvironmentBadge />
         </Providers>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,7 +5,6 @@ import { Suspense, type ReactNode } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { SessionProvider } from 'next-auth/react';
-import { Web3ContextProvider } from '@/lib/web3/context-provider';
 import {
   AuthProvider,
   SidebarProvider,
@@ -21,20 +20,18 @@ export default function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
       <QueryClientProvider client={queryClient}>
-        <Web3ContextProvider>
-          <FeatureFlagsProvider>
-            <SidebarProvider>
-              <EnvironmentProvider>
-                <Suspense>
-                  <AuthProvider>
-                    <CollectionProvider>{children}</CollectionProvider>
-                  </AuthProvider>
-                </Suspense>
-              </EnvironmentProvider>
-            </SidebarProvider>
-          </FeatureFlagsProvider>
-          <ReactQueryDevtools initialIsOpen={false} />
-        </Web3ContextProvider>
+        <FeatureFlagsProvider>
+          <SidebarProvider>
+            <EnvironmentProvider>
+              <Suspense>
+                <AuthProvider>
+                  <CollectionProvider>{children}</CollectionProvider>
+                </AuthProvider>
+              </Suspense>
+            </EnvironmentProvider>
+          </SidebarProvider>
+        </FeatureFlagsProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </SessionProvider>
   );

--- a/components/campaign/detail-tab-rewards.tsx
+++ b/components/campaign/detail-tab-rewards.tsx
@@ -1,19 +1,23 @@
 import { CampaignDetailTabRewardsClient } from './detail-tab-rewards-client';
 import { CampaignDisplay } from '@/types/campaign';
+import { Web3ContextProvider } from '@/lib/web3/context-provider';
+
 export function CampaignDetailTabRewards({
   campaign,
 }: {
   campaign: CampaignDisplay;
 }) {
   return (
-    <div className="grid gap-6 md:grid-cols-[60%_40%] lg:grid-cols-[60%_40%]">
-      <div className="flex flex-col">
-        <CampaignDetailTabRewardsClient
-          campaignId={campaign.id.toString()}
-          campaignSlug={campaign.slug}
-          campaignOwner={campaign.creatorAddress}
-        />
+    <Web3ContextProvider>
+      <div className="grid gap-6 md:grid-cols-[60%_40%] lg:grid-cols-[60%_40%]">
+        <div className="flex flex-col">
+          <CampaignDetailTabRewardsClient
+            campaignId={campaign.id.toString()}
+            campaignSlug={campaign.slug}
+            campaignOwner={campaign.creatorAddress}
+          />
+        </div>
       </div>
-    </div>
+    </Web3ContextProvider>
   );
 }

--- a/components/campaign/donation/anonymous.tsx
+++ b/components/campaign/donation/anonymous.tsx
@@ -1,0 +1,18 @@
+import { Checkbox } from '@/components/ui';
+
+export function CampaignDonationAnonymous() {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Checkbox id="anonymous" />
+        <label htmlFor="anonymous" className="text-sm font-medium">
+          Make my donation anonymous
+        </label>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        By checking this, we won&apos;t consider your profile information as a
+        donor for this donation and won&apos;t show it on public pages.
+      </p>
+    </div>
+  );
+}

--- a/components/campaign/donation/details-credit-card.tsx
+++ b/components/campaign/donation/details-credit-card.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { Wallet, HelpCircle, CreditCard } from 'lucide-react';
+import {
+  Button,
+  Card,
+  CardContent,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  SelectValue,
+  Badge,
+  Switch,
+  Input,
+  Checkbox,
+} from '@/components/ui';
+import { Campaign } from '@/types/campaign';
+
+export function CampaignDonationDetails({ campaign: Campaign }) {
+  const [isDonatingToAkashic, setIsDonatingToAkashic] = useState(false);
+  const [percentage, setPercentage] = useState(10);
+  const [amount, setAmount] = useState('');
+  return (
+    <>
+      <div className="space-y-4">
+        {!stripeData && (
+          <div className="relative">
+            <div className="flex rounded-md border shadow-sm">
+              <div className="relative flex flex-1">
+                <Select
+                  value={'USD'}
+                  onValueChange={setSelectedToken}
+                  disabled={true}
+                >
+                  <SelectTrigger className="w-[120px] rounded-r-none border-0 bg-muted">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USD">USD</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="number"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  className="rounded-l-none border-0 border-l"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+        {showDonateButton && (
+          <Button
+            className="w-full"
+            size="lg"
+            disabled={!numericAmount || isProcessing}
+            onClick={onStripePayment}
+          >
+            {isProcessing ? 'Processing...' : `Donate with Card`}
+          </Button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/campaign/donation/details-eligible.tsx
+++ b/components/campaign/donation/details-eligible.tsx
@@ -1,0 +1,21 @@
+import { Campaign } from '@/types/campaign';
+import { Badge } from '@/components/ui';
+export function CampaignDonationDetailsEligible({
+  campaign,
+}: {
+  campaign: Campaign;
+}) {
+  if (!campaign.treasuryAddress) {
+    return null;
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <Badge
+        variant="secondary"
+        className="bg-teal-50 text-teal-600 hover:bg-teal-50"
+      >
+        <span className="mr-1">👋</span> Eligible for matching
+      </Badge>
+    </div>
+  );
+}

--- a/components/campaign/donation/details.tsx
+++ b/components/campaign/donation/details.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState } from 'react';
+import { Wallet, HelpCircle, CreditCard } from 'lucide-react';
+import {
+  Button,
+  Card,
+  CardContent,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  SelectValue,
+  Badge,
+  Switch,
+  Input,
+  Checkbox,
+} from '@/components/ui';
+import { Campaign } from '@/types/campaign';
+
+export function CampaignDonationDetails({ campaign: Campaign }) {
+  const [isDonatingToAkashic, setIsDonatingToAkashic] = useState(false);
+  const [percentage, setPercentage] = useState(10);
+  const [amount, setAmount] = useState('');
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <Badge
+          variant="secondary"
+          className="bg-teal-50 text-teal-600 hover:bg-teal-50"
+        >
+          <span className="mr-1">👋</span> Eligible for matching
+        </Badge>
+      </div>
+
+      <div className="space-y-4">
+        {(!stripeData || paymentMethod === 'wallet') && (
+          <div className="relative">
+            <div className="flex rounded-md border shadow-sm">
+              <div className="relative flex flex-1">
+                <Select
+                  value={paymentMethod === 'wallet' ? selectedToken : 'USD'}
+                  onValueChange={setSelectedToken}
+                  disabled={paymentMethod === 'card'}
+                >
+                  <SelectTrigger className="w-[120px] rounded-r-none border-0 bg-muted">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {paymentMethod === 'wallet' ? (
+                      <SelectItem value="USDC">USDC</SelectItem>
+                    ) : (
+                      <SelectItem value="USD">USD</SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="number"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  className="rounded-l-none border-0 border-l"
+                />
+              </div>
+              {paymentMethod === 'wallet' && (
+                <div className="flex items-center px-3 text-sm text-muted-foreground">
+                  {formatUSD(numericAmount)}
+                </div>
+              )}
+            </div>
+            {paymentMethod === 'wallet' && (
+              <div className="mt-1 text-sm text-muted-foreground">
+                Available: {availableBalance}
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <HelpCircle className="ml-1 inline h-4 w-4" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Your available balance in {selectedToken}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            )}
+          </div>
+        )}
+
+        {showDonationDetails && (
+          <>
+            <div>
+              <div className="mb-2 flex items-center gap-2">
+                <Switch
+                  checked={isDonatingToAkashic}
+                  onCheckedChange={setIsDonatingToAkashic}
+                />
+                <span className="text-sm">Donate to Akashic</span>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <HelpCircle className="h-4 w-4" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Choose a percentage to donate to Akashic</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              {isDonatingToAkashic && (
+                <div className="flex gap-2">
+                  {[5, 10, 15, 20].map((value) => (
+                    <Button
+                      key={value}
+                      variant={percentage === value ? 'default' : 'outline'}
+                      onClick={() => setPercentage(value)}
+                      className="flex-1"
+                    >
+                      {value}%
+                    </Button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-4 rounded-lg bg-muted/50 p-4">
+              <div className="flex justify-between text-sm">
+                <span>Donating to {campaign.title}</span>
+                <span className="font-medium">{formatCrypto(poolAmount)}</span>
+              </div>
+              {isDonatingToAkashic && (
+                <div className="flex justify-between text-sm">
+                  <span>Donating {percentage}% to Akashic</span>
+                  <span className="font-medium">
+                    {formatCrypto(akashicAmount)}
+                  </span>
+                </div>
+              )}
+              <div className="flex justify-between text-sm font-semibold">
+                <span>Your total donation</span>
+                <span>{formatCrypto(numericAmount)}</span>
+              </div>
+            </div>
+          </>
+        )}
+
+        {showDonateButton && (
+          <Button
+            className="w-full"
+            size="lg"
+            disabled={!numericAmount || isProcessing}
+            onClick={paymentMethod === 'wallet' ? onDonate : onStripePayment}
+          >
+            {isProcessing
+              ? 'Processing...'
+              : `Donate with ${paymentMethod === 'wallet' ? 'Wallet' : 'Card'}`}
+          </Button>
+        )}
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Checkbox id="anonymous" />
+            <label htmlFor="anonymous" className="text-sm font-medium">
+              Make my donation anonymous
+            </label>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            By checking this, we won&apos;t consider your profile information as
+            a donor for this donation and won&apos;t show it on public pages.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/campaign/donation/form.tsx
+++ b/components/campaign/donation/form.tsx
@@ -1,0 +1,48 @@
+import {
+  Card,
+  CardContent,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@/components/ui';
+import { Wallet, CreditCard } from 'lucide-react';
+import { Campaign } from '@/types/campaign';
+import { CampaignDonationTabWallet } from '@/components/campaign/donation/wallet/tab';
+import { Web3ContextProvider } from '@/lib/web3/context-provider';
+export function CampaignDonationForm({ campaign }: { campaign: Campaign }) {
+  return (
+    <Card className="border-0 shadow-none">
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <h2 className="text-lg font-medium">How do you want to donate?</h2>
+        </div>
+        <Tabs defaultValue="wallet">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="card" className="flex items-center gap-2">
+              <CreditCard className="h-4 w-4" />
+              Credit Card
+            </TabsTrigger>
+            <TabsTrigger value="wallet" className="flex items-center gap-2">
+              <Wallet className="h-4 w-4" />
+              Crypto Wallet
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="wallet">
+            <Web3ContextProvider>
+              <CampaignDonationTabWallet campaign={campaign} />
+            </Web3ContextProvider>
+          </TabsContent>
+
+          <TabsContent value="card">
+            {/* <CampaignDonationTabCreditCard
+              campaign={campaign}
+              amount={amount}
+            /> */}
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/campaign/donation/tab-credit-card.tsx
+++ b/components/campaign/donation/tab-credit-card.tsx
@@ -1,0 +1,46 @@
+import { Elements } from '@stripe/react-stripe-js';
+import { PaymentStripeForm } from '@/components/payment/stripe-form';
+import { CreditCard } from 'lucide-react';
+import { useStripePaymentCallback } from '@/hooks/use-stripe';
+import { Campaign } from '@/types/campaign';
+
+export function CampaignDonationTabCreditCard({
+  amount,
+  campaign,
+}: {
+  amount: string;
+  campaign: Campaign;
+}) {
+  const {
+    onStripePayment,
+    error: stripeError,
+    isProcessing: isStripeProcessing,
+    stripeData,
+    stripePromise,
+  } = useStripePaymentCallback({
+    amount,
+  });
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <CreditCard className="h-4 w-4" />
+        <span className="text-sm">Secure payment via Stripe</span>
+      </div>
+      {stripeData && stripePromise && (
+        <Elements
+          stripe={stripePromise}
+          options={{
+            clientSecret: stripeData.clientSecret,
+            appearance: { theme: 'stripe' },
+          }}
+        >
+          <PaymentStripeForm
+            publicKey={stripeData.publicKey}
+            campaign={campaign}
+            amount={amount}
+          />
+        </Elements>
+      )}
+    </>
+  );
+}

--- a/components/campaign/donation/wallet/akashic.tsx
+++ b/components/campaign/donation/wallet/akashic.tsx
@@ -1,0 +1,61 @@
+import {
+  Button,
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui';
+import { HelpCircle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+export function CampaignDonationWalletAkashic({
+  onChange,
+}: {
+  onChange: (percent: number) => void;
+}) {
+  const [isDonatingToAkashic, setIsDonatingToAkashic] = useState(false);
+  const [percentage, setPercentage] = useState(10);
+  useEffect(() => {
+    if (!isDonatingToAkashic) {
+      onChange(0);
+      return;
+    }
+    onChange(percentage);
+  }, [percentage, isDonatingToAkashic]);
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-2">
+        <Switch
+          checked={isDonatingToAkashic}
+          onCheckedChange={setIsDonatingToAkashic}
+        />
+        <span className="text-sm">Donate to Akashic</span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <HelpCircle className="h-4 w-4" />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Choose a percentage to donate to Akashic</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      {isDonatingToAkashic && (
+        <div className="flex gap-2">
+          {[5, 10, 15, 20].map((value) => (
+            <Button
+              key={value}
+              variant={percentage === value ? 'default' : 'outline'}
+              onClick={() => setPercentage(value)}
+              className="flex-1"
+            >
+              {value}%
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/campaign/donation/wallet/amount.tsx
+++ b/components/campaign/donation/wallet/amount.tsx
@@ -1,0 +1,58 @@
+import { useCallback, type ChangeEvent } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
+} from '@/components/ui';
+import { formatCrypto } from '@/lib/format-crypto';
+const supportedTokenList = ['USDC'];
+
+export function CampaignDonationWalletAmount({
+  amount,
+  selectedToken,
+  onAmountChanged,
+  onTokenChanged,
+}: {
+  amount: string;
+  selectedToken: string;
+  onAmountChanged: (amount: string) => void;
+  onTokenChanged: (token: string) => void;
+}) {
+  const intermediateOnAmountChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      return onAmountChanged(event.target.value);
+    },
+    [onAmountChanged],
+  );
+  const numericAmount = parseFloat(amount) || 0;
+  return (
+    <div className="flex rounded-md border shadow-sm">
+      <div className="relative flex flex-1">
+        <Select value={selectedToken} onValueChange={onTokenChanged}>
+          <SelectTrigger className="w-[120px] rounded-r-none border-0 bg-muted">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {supportedTokenList.map((supportedToken: string) => (
+              <SelectItem value={supportedToken} key={supportedToken}>
+                {supportedToken}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          type="number"
+          value={amount}
+          onChange={intermediateOnAmountChange}
+          className="ml-1 rounded-l-none border-0 border-l"
+        />
+      </div>
+      <div className="flex items-center px-3 text-sm text-muted-foreground">
+        {formatCrypto(numericAmount, selectedToken)}
+      </div>
+    </div>
+  );
+}

--- a/components/campaign/donation/wallet/balance.tsx
+++ b/components/campaign/donation/wallet/balance.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useMemo } from 'react';
+import { useUsdcBalance } from '@/lib/web3/hooks/use-usdc-balance';
+import { HelpCircle, Loader2 } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui';
+export function CampaignDonationWalletBalance({
+  selectedToken,
+}: {
+  selectedToken: string;
+}) {
+  const { usdcBalance, isPending: usdBalanceIsPending } = useUsdcBalance();
+  const availableBalance = useMemo(() => {
+    if (selectedToken === 'USDC') {
+      if (usdBalanceIsPending) {
+        return (
+          <>
+            <Loader2 /> Pending
+          </>
+        );
+      }
+      return usdcBalance;
+    }
+    return 'unknown';
+  }, [usdcBalance, selectedToken, usdBalanceIsPending]);
+
+  return (
+    <div className="mt-1 flex flex-nowrap text-sm text-muted-foreground">
+      Available: {availableBalance} {selectedToken}
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>
+            <HelpCircle className="ml-1 inline h-4 w-4" />
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Your available balance in {selectedToken}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/components/campaign/donation/wallet/details.tsx
+++ b/components/campaign/donation/wallet/details.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Campaign } from '@/types/campaign';
+import { CampaignDonationWalletBalance } from './balance';
+import { CampaignDonationWalletAmount } from './amount';
+import { CampaignDonationWalletAkashic } from './akashic';
+import { CampaignDonationWalletProcess } from './process';
+
+export function CampaignDonationDetails({ campaign }: { campaign: Campaign }) {
+  const [selectedToken, setSelectedToken] = useState('USDC');
+  const [processing, setProcessing] = useState(false);
+  const [amount, setAmount] = useState('0');
+  const [donationToAkashic, setDonationToAkashic] = useState(0);
+  return (
+    <>
+      <div className="space-y-4">
+        <div className="relative">
+          <CampaignDonationWalletAmount
+            onAmountChanged={setAmount}
+            onTokenChanged={setSelectedToken}
+            amount={amount}
+            selectedToken={selectedToken}
+          />
+          <CampaignDonationWalletBalance selectedToken={selectedToken} />
+          <CampaignDonationWalletAkashic onChange={setDonationToAkashic} />
+          <CampaignDonationWalletProcess
+            campaign={campaign}
+            onProcessing={setProcessing}
+            amount={amount}
+            donationToAkashic={donationToAkashic}
+            selectedToken={selectedToken}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/campaign/donation/wallet/process.tsx
+++ b/components/campaign/donation/wallet/process.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@/components/ui';
+import { useDonationCallback } from '@/hooks/use-donation';
+import { Campaign } from '@/types/campaign';
+import { useEffect, useMemo } from 'react';
+
+export function CampaignDonationWalletProcess({
+  campaign,
+  amount,
+  selectedToken,
+  donationToAkashic,
+  onProcessing,
+}: {
+  campaign: Campaign;
+  amount: string;
+  selectedToken: string;
+  donationToAkashic: number;
+  onProcessing: (processing: boolean) => void;
+}) {
+  const {
+    onDonate,
+    isProcessing,
+    error: donateError,
+  } = useDonationCallback({
+    campaign,
+    amount,
+    selectedToken,
+  });
+  const numericAmount = useMemo(() => parseFloat(amount) || 0, [amount]);
+  const akashicAmount = useMemo(() => {
+    if (donationToAkashic) {
+      return (numericAmount * donationToAkashic) / 100;
+    }
+    return 0;
+  }, [numericAmount, donationToAkashic]);
+  const poolAmount = useMemo(() => {
+    return numericAmount - akashicAmount;
+  }, [numericAmount, akashicAmount]);
+  useEffect(() => {
+    onProcessing(isProcessing);
+  }, [onProcessing, isProcessing]);
+  return (
+    <Button
+      className="w-full"
+      size="lg"
+      disabled={!numericAmount || isProcessing}
+      onClick={onDonate}
+    >
+      {isProcessing ? 'Processing...' : `Donate with Wallet`}
+    </Button>
+  );
+}

--- a/components/campaign/donation/wallet/tab.tsx
+++ b/components/campaign/donation/wallet/tab.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { useState } from 'react';
+import { Loader2, MessageSquareWarning, Wallet } from 'lucide-react';
+import { PaymentSwitchWalletNetwork } from '@/components/payment/switch-wallet-network';
+import { useNetworkCheck } from '@/hooks/use-network';
+import { useAuth as useWeb3Auth, chainConfig } from '@/lib/web3';
+import { useAuth } from '@/contexts';
+import { CampaignDonationDetails } from './details';
+import { CampaignDonationDetailsEligible } from '@/components/campaign/donation/details-eligible';
+import { Campaign } from '@/types/campaign';
+import { Button } from '@/components/ui';
+
+export function CampaignDonationTabWallet({
+  campaign,
+}: {
+  campaign: Campaign;
+}) {
+  const { isCorrectNetwork } = useNetworkCheck();
+  const { ready } = useWeb3Auth();
+  const { authenticated, login } = useAuth();
+  if (!authenticated) {
+    return (
+      <>
+        <div className="flex items-center justify-between">
+          <MessageSquareWarning /> You need to be signed in to donate
+        </div>
+        <div className="flex items-center justify-between">
+          <Button onClick={login}>Login</Button>
+        </div>
+      </>
+    );
+  }
+  if (!ready) {
+    return (
+      <div className="flex items-center justify-between">
+        <Loader2 /> Connecting to wallet
+      </div>
+    );
+  }
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        {isCorrectNetwork ? (
+          <>
+            <div className="flex items-center gap-2">
+              <Wallet className="h-4 w-4" />
+              <span className="text-sm">
+                Saving gas fees, network {chainConfig.name} used.
+              </span>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center gap-2">
+              <Wallet className="h-4 w-4" />
+              <span className="text-sm">Save on gas fees, switch network.</span>
+            </div>
+            <PaymentSwitchWalletNetwork />
+          </>
+        )}
+      </div>
+      <CampaignDonationDetailsEligible campaign={campaign} />
+      <CampaignDonationDetails campaign={campaign} />
+    </>
+  );
+}

--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -26,13 +26,12 @@ import {
 import { ErrorAlert } from '@/components/error-alert';
 import { Wallet, HelpCircle, CreditCard } from 'lucide-react';
 import { Campaign } from '@/types/campaign';
-import { Elements } from '@stripe/react-stripe-js';
-import { PaymentStripeForm } from '@/components/payment/stripe-form';
-import { PaymentSwitchWalletNetwork } from '@/components/payment/switch-wallet-network';
 import { useStripePaymentCallback } from '@/hooks/use-stripe';
-import { useNetworkCheck } from '@/hooks/use-network';
+//import { useNetworkCheck } from '@/hooks/use-network';
 import { useDonationCallback } from '@/hooks/use-donation';
-import { useUsdcBalance } from '@/lib/web3/hooks/use-usdc-balance';
+import { CampaignDonationTabWallet } from './campaign/donation/wallet/tab';
+import { CampaignDonationTabCreditCard } from './campaign/donation/tab-credit-card';
+//import { useUsdcBalance } from '@/lib/web3/hooks/use-usdc-balance';
 
 interface DonationFormProps {
   campaign: Campaign;
@@ -44,10 +43,8 @@ export default function DonationForm({ campaign }: DonationFormProps) {
   const [percentage, setPercentage] = useState(10);
   const [isDonatingToAkashic, setIsDonatingToAkashic] = useState(false);
   const [paymentMethod, setPaymentMethod] = useState<'wallet' | 'card'>('card');
-  const usdcBalance = useUsdcBalance();
   // Simulated values - in a real app these would come from an API or wallet
   const tokenPrice = 1; // USD per USDC
-  const availableBalance = usdcBalance; // Update available balance to use fetched USDC balance
 
   const numericAmount = parseFloat(amount) || 0;
   const akashicAmount = isDonatingToAkashic
@@ -55,11 +52,8 @@ export default function DonationForm({ campaign }: DonationFormProps) {
     : 0;
   const poolAmount = numericAmount - akashicAmount;
 
-  const formatCrypto = (value: number) =>
-    `${value.toFixed(6)} ${selectedToken}`;
-  const formatUSD = (value: number) => `$ ${(value * tokenPrice).toFixed(2)}`;
-
-  const { isCorrectNetwork } = useNetworkCheck();
+  //const { isCorrectNetwork } = useNetworkCheck();
+  const isCorrectNetwork = true;
   const {
     onDonate,
     isProcessing: isDonateProcessing,
@@ -149,189 +143,16 @@ export default function DonationForm({ campaign }: DonationFormProps) {
           </TabsList>
 
           <TabsContent value="wallet">
-            <div className="flex items-center justify-between">
-              {!isCorrectNetwork && (
-                <div className="flex items-center gap-2">
-                  <Wallet className="h-4 w-4" />
-                  <span className="text-sm">
-                    Save on gas fees, switch network.
-                  </span>
-                </div>
-              )}
-              <PaymentSwitchWalletNetwork />
-            </div>
+            <CampaignDonationTabWallet campaign={campaign} />
           </TabsContent>
 
           <TabsContent value="card">
-            <div className="flex items-center gap-2">
-              <CreditCard className="h-4 w-4" />
-              <span className="text-sm">Secure payment via Stripe</span>
-            </div>
-            {stripeData && stripePromise && (
-              <Elements
-                stripe={stripePromise}
-                options={{
-                  clientSecret: stripeData.clientSecret,
-                  appearance: { theme: 'stripe' },
-                }}
-              >
-                <PaymentStripeForm
-                  publicKey={stripeData.publicKey}
-                  campaign={campaign}
-                  amount={amount}
-                />
-              </Elements>
-            )}
+            <CampaignDonationTabCreditCard
+              campaign={campaign}
+              amount={amount}
+            />
           </TabsContent>
         </Tabs>
-
-        <div className="flex items-center gap-2">
-          <Badge
-            variant="secondary"
-            className="bg-teal-50 text-teal-600 hover:bg-teal-50"
-          >
-            <span className="mr-1">👋</span> Eligible for matching
-          </Badge>
-        </div>
-
-        <div className="space-y-4">
-          {(!stripeData || paymentMethod === 'wallet') && (
-            <div className="relative">
-              <div className="flex rounded-md border shadow-sm">
-                <div className="relative flex flex-1">
-                  <Select
-                    value={paymentMethod === 'wallet' ? selectedToken : 'USD'}
-                    onValueChange={setSelectedToken}
-                    disabled={paymentMethod === 'card'}
-                  >
-                    <SelectTrigger className="w-[120px] rounded-r-none border-0 bg-muted">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {paymentMethod === 'wallet' ? (
-                        <SelectItem value="USDC">USDC</SelectItem>
-                      ) : (
-                        <SelectItem value="USD">USD</SelectItem>
-                      )}
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    type="number"
-                    value={amount}
-                    onChange={(e) => setAmount(e.target.value)}
-                    className="rounded-l-none border-0 border-l"
-                  />
-                </div>
-                {paymentMethod === 'wallet' && (
-                  <div className="flex items-center px-3 text-sm text-muted-foreground">
-                    {formatUSD(numericAmount)}
-                  </div>
-                )}
-              </div>
-              {paymentMethod === 'wallet' && (
-                <div className="mt-1 text-sm text-muted-foreground">
-                  Available: {availableBalance}
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <HelpCircle className="ml-1 inline h-4 w-4" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>Your available balance in {selectedToken}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              )}
-            </div>
-          )}
-
-          {showDonationDetails && (
-            <>
-              <div>
-                <div className="mb-2 flex items-center gap-2">
-                  <Switch
-                    checked={isDonatingToAkashic}
-                    onCheckedChange={setIsDonatingToAkashic}
-                  />
-                  <span className="text-sm">Donate to Akashic</span>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <HelpCircle className="h-4 w-4" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>Choose a percentage to donate to Akashic</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                {isDonatingToAkashic && (
-                  <div className="flex gap-2">
-                    {[5, 10, 15, 20].map((value) => (
-                      <Button
-                        key={value}
-                        variant={percentage === value ? 'default' : 'outline'}
-                        onClick={() => setPercentage(value)}
-                        className="flex-1"
-                      >
-                        {value}%
-                      </Button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div className="space-y-4 rounded-lg bg-muted/50 p-4">
-                <div className="flex justify-between text-sm">
-                  <span>Donating to {campaign.title}</span>
-                  <span className="font-medium">
-                    {formatCrypto(poolAmount)}
-                  </span>
-                </div>
-                {isDonatingToAkashic && (
-                  <div className="flex justify-between text-sm">
-                    <span>Donating {percentage}% to Akashic</span>
-                    <span className="font-medium">
-                      {formatCrypto(akashicAmount)}
-                    </span>
-                  </div>
-                )}
-                <div className="flex justify-between text-sm font-semibold">
-                  <span>Your total donation</span>
-                  <span>{formatCrypto(numericAmount)}</span>
-                </div>
-              </div>
-            </>
-          )}
-
-          {showDonateButton && (
-            <Button
-              className="w-full"
-              size="lg"
-              disabled={!numericAmount || isProcessing}
-              onClick={paymentMethod === 'wallet' ? onDonate : onStripePayment}
-            >
-              {isProcessing
-                ? 'Processing...'
-                : `Donate with ${paymentMethod === 'wallet' ? 'Wallet' : 'Card'}`}
-            </Button>
-          )}
-
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <Checkbox id="anonymous" />
-              <label htmlFor="anonymous" className="text-sm font-medium">
-                Make my donation anonymous
-              </label>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              By checking this, we won&apos;t consider your profile information
-              as a donor for this donation and won&apos;t show it on public
-              pages.
-            </p>
-          </div>
-        </div>
       </CardContent>
     </Card>
   );

--- a/components/payment/switch-wallet-network.tsx
+++ b/components/payment/switch-wallet-network.tsx
@@ -1,12 +1,15 @@
+'use client';
 import { Button } from '@/components/ui';
 import { useCallback } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { useNetworkCheck } from '@/hooks/use-network';
-import { AlertCircle } from 'lucide-react';
-import { chainConfig } from '@/lib/web3';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import { useAuth, chainConfig } from '@/lib/web3';
+
 export function PaymentSwitchWalletNetwork() {
   const { toast } = useToast();
   const { isCorrectNetwork, switchNetwork } = useNetworkCheck();
+  const { ready } = useAuth();
 
   const handleNetworkSwitch = useCallback(async () => {
     try {
@@ -29,6 +32,18 @@ export function PaymentSwitchWalletNetwork() {
       });
     }
   }, [switchNetwork, toast]);
+  if (!ready) {
+    return (
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={true}
+        className="w-full text-black"
+      >
+        <Loader2 /> Connecting to Wallet
+      </Button>
+    );
+  }
   if (isCorrectNetwork) {
     return null;
   }

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -9,14 +9,11 @@ import React, {
 } from 'react';
 
 const debug = process.env.NODE_ENV !== 'production';
-import { useAuth as useWeb3Auth } from '@/lib/web3';
-import { ConnectedWallet } from '@/lib/web3/types';
-import { useSession } from 'next-auth/react';
+import { useSession, signIn, signOut } from 'next-auth/react';
 
 interface AuthContextType {
   address?: string;
   authenticated: boolean;
-  wallet?: ConnectedWallet;
   isAdmin: boolean;
   isClient: boolean;
   isReady: boolean;
@@ -27,7 +24,6 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType>({
   address: undefined,
   authenticated: false,
-  wallet: undefined,
   isAdmin: false,
   isClient: false,
   isReady: false,
@@ -38,13 +34,6 @@ const AuthContext = createContext<AuthContextType>({
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const {
-    address: web3Address,
-    wallet,
-    login,
-    logout,
-    ready: web3Ready,
-  } = useWeb3Auth();
   const session = useSession();
 
   const [isClient, setIsClient] = useState(false);
@@ -60,32 +49,25 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const isReady = useMemo(() => {
     debug &&
-      console.log(
-        'contexts/AuthContext: rememo isReady',
-        session.status,
-        web3Ready,
-      );
+      console.log('contexts/AuthContext: rememo isReady', session.status);
     if (session.status === 'loading') {
       return false;
     }
-    return web3Ready;
-  }, [web3Ready, session]);
+    return true;
+  }, [session]);
 
   const address = useMemo(() => {
     debug &&
       console.log(
         'contexts/AuthContext: rememo address',
         session?.data?.user?.address,
-        web3Address,
       );
-    if (web3Address) {
-      return web3Address;
-    }
+
     if (typeof session?.data?.user?.address !== 'string') {
       return undefined;
     }
     return session.data.user.address;
-  }, [session, web3Address]);
+  }, [session]);
   // Set client-side flag on mount
   useEffect(() => {
     setIsClient(true);
@@ -113,23 +95,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     return {
       address,
       authenticated,
-      wallet,
       isReady,
       isAdmin,
       isClient,
-      login,
-      logout,
+      login: signIn,
+      logout: signOut,
     };
-  }, [
-    address,
-    authenticated,
-    wallet,
-    isReady,
-    isAdmin,
-    isClient,
-    login,
-    logout,
-  ]);
+  }, [address, authenticated, isReady, isAdmin, isClient]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/hooks/use-network.ts
+++ b/hooks/use-network.ts
@@ -16,15 +16,18 @@ export function useNetworkCheck() {
   const { chainId } = useCurrentChain();
   const { ready } = useAuth();
   const { toast } = useToast();
+  const [triggerCheck, setTriggerCheck] = useState(Date.now());
   const [isCorrectNetwork, setIsCorrectNetwork] = useState(false);
 
   const checkNetwork = useCallback(async () => {
+    console.log('use-network::checkNetwork');
     const provider = getProvider();
     if (!provider) {
       return;
     }
     try {
-      const correctNetwork = chainId === chainConfig.chainId.decimal;
+      console.log('use-network::checkNetwork', chainId, chainConfig.chainId);
+      const correctNetwork = chainId === chainConfig.chainId;
       setIsCorrectNetwork(correctNetwork);
       return correctNetwork;
     } catch (error) {
@@ -33,6 +36,9 @@ export function useNetworkCheck() {
       return false;
     }
   }, [chainId]);
+  useEffect(() => {
+    checkNetwork();
+  }, [checkNetwork, triggerCheck]);
 
   const switchNetwork = useCallback(async () => {
     const provider = getProvider();
@@ -41,14 +47,14 @@ export function useNetworkCheck() {
     }
 
     try {
-      const chainIdHex = chainConfig.chainId.hex;
+      const chainIdHex = `0x${chainConfig.chainId?.toString(16)}`;
 
       try {
         await provider.request({
           method: 'wallet_switchEthereumChain',
           params: [{ chainId: chainIdHex }],
         });
-        await checkNetwork();
+        setTriggerCheck(Date.now());
       } catch (switchError) {
         // This error code indicates that the chain has not been added to MetaMask
         if (
@@ -63,8 +69,7 @@ export function useNetworkCheck() {
               method: 'wallet_addEthereumChain',
               params: [chainConfig.getAddChainParams()],
             });
-            // Check network again after adding
-            await checkNetwork();
+            setTriggerCheck(Date.now());
           } catch (addError) {
             console.error('Error adding network:', addError);
             throw new Error('Failed to add network');
@@ -86,7 +91,7 @@ export function useNetworkCheck() {
         variant: 'destructive',
       });
     }
-  }, [ready, toast, checkNetwork]);
+  }, [ready, toast]);
 
   useEffect(() => {
     if (!address) {
@@ -111,7 +116,7 @@ export function useNetworkCheck() {
         }
 
         // Initial network check
-        await checkNetwork();
+        setTriggerCheck(Date.now());
 
         // Listen for network changes
         const handleChainChanged = async (newChainIdHex: string) => {

--- a/lib/api/campaigns.ts
+++ b/lib/api/campaigns.ts
@@ -6,9 +6,6 @@ import { chainConfig, createPublicClient, http } from '@/lib/web3';
 import { QueryClient } from '@tanstack/react-query';
 import { CAMPAIGNS_QUERY_KEY } from '@/lib/hooks/useCampaigns';
 
-const FACTORY_ADDRESS = process.env.NEXT_PUBLIC_CAMPAIGN_INFO_FACTORY;
-const RPC_URL = chainConfig.rpcUrl;
-
 export type PaymentWithUser = Payment & {
   user: User;
 };
@@ -46,6 +43,8 @@ export async function getCampaignBySlug(
 }
 
 async function getPublicClient() {
+  const FACTORY_ADDRESS = process.env.NEXT_PUBLIC_CAMPAIGN_INFO_FACTORY;
+  const RPC_URL = chainConfig.rpcUrl;
   if (!FACTORY_ADDRESS || !RPC_URL) {
     throw new Error('Campaign factory address or RPC URL not configured');
   }

--- a/lib/format-crypto.ts
+++ b/lib/format-crypto.ts
@@ -1,0 +1,3 @@
+export function formatCrypto(value: number, selectedToken: string) {
+  return `${value.toFixed(6)} ${selectedToken}`;
+}

--- a/lib/format-usd.ts
+++ b/lib/format-usd.ts
@@ -1,0 +1,3 @@
+export function formatUSD(value: number, tokenPrice: number) {
+  return `$ ${(value * tokenPrice).toFixed(2)}`;
+}

--- a/lib/web3/adapter/dummy/config.ts
+++ b/lib/web3/adapter/dummy/config.ts
@@ -1,35 +1,71 @@
 import type { Chain } from '@/lib/web3/types';
 
+const mockEthereum = {
+  id: 1,
+  name: 'Ethereum',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://eth.merkle.io'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Etherscan',
+      url: 'https://etherscan.io',
+      apiUrl: 'https://api.etherscan.io/api',
+    },
+  },
+  contracts: {
+    ensRegistry: {
+      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    },
+    ensUniversalResolver: {
+      address: '0xce01f8eee7E479C928F8919abD53E553a36CeF67',
+      blockCreated: 19_258_213,
+    },
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 14_353_601,
+    },
+  },
+};
+const mockAlfajores = {
+  id: 44787,
+  name: 'Alfajores',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'CELO',
+    symbol: 'A-CELO',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://alfajores-forno.celo-testnet.org'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Celo Alfajores Explorer',
+      url: 'https://celo-alfajores.blockscout.com',
+      apiUrl: 'https://celo-alfajores.blockscout.com/api',
+    },
+  },
+};
 export const wagmiConfig = {
-  chains: [] as Chain[],
+  chains: [mockEthereum, mockAlfajores] as Chain[],
   connectors: [],
   transports: {},
   ssr: true,
 };
 
+const defaultChain = mockAlfajores;
 export const chainConfig = {
-  chainId: 0,
-  name: 'dummy',
-  nativeCurrency: { decimals: 2, name: 'DMMY', symbol: 'DMMY' },
-  rpcUrl: 'http://localhost:1414/rpc',
-  blockExplorerUrl: 'http://localhost:1414/explorer',
-  defaultChain: {
-    id: 0,
-    name: 'dummy',
-    nativeCurrency: { decimals: 2, name: 'DMMY', symbol: 'DMMY' },
-    rpcUrls: {
-      default: {
-        http: ['http://localhost:1414/rpc'],
-      },
-    },
-    blockExplorers: {
-      default: {
-        name: 'Dummy Explorer',
-        url: 'http://localhost:1414/explorer',
-        apiUrl: 'http://localhost:1414/explorer/api',
-      },
-    },
-  },
+  chainId: defaultChain.id,
+  name: defaultChain.name,
+  nativeCurrency: defaultChain.nativeCurrency,
+  rpcUrl: defaultChain.rpcUrls.default.http[0],
+  blockExplorerUrl: defaultChain.blockExplorers.default.url,
+  defaultChain,
   getAddChainParams() {
     return {
       chainId: this.chainId,

--- a/lib/web3/adapter/dummy/context-provider.tsx
+++ b/lib/web3/adapter/dummy/context-provider.tsx
@@ -1,14 +1,88 @@
-import { type ReactNode } from 'react';
+'use client';
 
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+interface IWeb3ContextChain {
+  name?: string;
+  blockExplorers?: { default: { url: string } };
+}
+
+interface IWeb3Context {
+  chainId?: number;
+  chain?: IWeb3ContextChain;
+  address?: string;
+  initialized: boolean;
+  requestWallet: () => Promise<{ address?: `0x${string}`; chainId?: number }>;
+}
+const Web3Context = createContext({
+  chainId: undefined,
+  chain: undefined,
+  address: undefined,
+  initialized: false,
+  requestWallet: async () => ({ address: undefined, chainId: undefined }),
+} as IWeb3Context);
+
+const initTime = 500;
 export function Web3ContextProvider({ children }: { children: ReactNode }) {
-  return children;
+  const [initialized, setInitialized] = useState(false);
+  const [address, setAddress] = useState<`0x${string}` | undefined>();
+  const [chainId, setChainId] = useState(0);
+  useEffect(() => {
+    // mock that loading web3 components might take time
+    const timer = setTimeout(() => {
+      setInitialized(true);
+      setAddress('0x0000deb0000');
+    }, initTime);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+  useEffect(() => {
+    // Event handler to update context state
+    const handleDummyChainIdChanged = (event: CustomEvent) => {
+      const eventChainId = parseInt(event.detail.chainId, 16);
+      if (eventChainId !== chainId) {
+        console.log('dummyChainId changed', chainId, eventChainId);
+        setChainId(eventChainId);
+      }
+    };
+
+    // Listen for the custom event
+    window.addEventListener('dummyChainId', handleDummyChainIdChanged);
+
+    // Cleanup the event listener on unmount
+    return () => {
+      window.removeEventListener('dummyChainId', handleDummyChainIdChanged);
+    };
+  }, []);
+  const value = useMemo(() => {
+    console.log('dummy::context-provider rememo value');
+    return {
+      chainId,
+      chain: {},
+      address,
+      initialized,
+      requestWallet: async () => {
+        return {
+          chainId,
+          address,
+          isConnected: async () => {
+            return initialized;
+          },
+        } as {
+          address?: `0x${string}`;
+          chainId?: number;
+        };
+      },
+    };
+  }, [initialized, address, chainId]);
+  return <Web3Context.Provider value={value}>{children}</Web3Context.Provider>;
 }
-export function useWeb3Context() {
-  return {
-    chainId: 0,
-    chain: {},
-    address: '0x00',
-    initialized: true,
-    requestWallet: () => {},
-  };
-}
+export const useWeb3Context = () => useContext(Web3Context);

--- a/lib/web3/adapter/dummy/ethers.ts
+++ b/lib/web3/adapter/dummy/ethers.ts
@@ -1,3 +1,81 @@
 // ethers 1522 -> 1837,  200-500ms
 // export { ethers } from 'ethers';
-export const ethers = {};
+const contractTime = 500;
+interface IContractReturn {
+  wait: () => Promise<{ status: number }>;
+  hash: string;
+}
+async function getMockContractReturn(): Promise<IContractReturn> {
+  return {
+    wait: async () => {
+      await new Promise((resolve) => setTimeout(resolve, contractTime));
+      return { status: 1 };
+    },
+    hash: `0x${Math.round(Math.random() * 100000).toString(16)}`,
+  };
+}
+
+interface IPledgeWithoutAReward {
+  (
+    address: string,
+    usdc: number,
+    options: unknown,
+  ): (
+    address: string,
+    usdc: number,
+    options: unknown,
+  ) => Promise<IContractReturn>; // Callable function type
+  estimateGas: () => Promise<bigint>; // Method type
+}
+export const ethers = {
+  BrowserProvider: class {
+    constructor(inputProvider: unknown) {
+      console.log('new ethers.BrowserProvider', inputProvider);
+    }
+    async getSigner() {
+      return { address: '0x000bad' };
+    }
+  },
+  Contract: class {
+    pledgeWithoutAReward: IPledgeWithoutAReward;
+    constructor(address: string, abi: unknown, signer: unknown) {
+      const pledgeWithoutAReward: IPledgeWithoutAReward = (async (
+        address: string,
+        usdc: number,
+        options: unknown,
+      ) => {
+        console.log('pledgeWithoutAReward', { address, usdc, options });
+        return getMockContractReturn();
+      }) as unknown as IPledgeWithoutAReward;
+      pledgeWithoutAReward.estimateGas = async () => {
+        return 100000n;
+      };
+      this.pledgeWithoutAReward = pledgeWithoutAReward;
+      console.log('new ethers.Contract', address, abi, signer);
+    }
+    async balanceOf() {
+      await new Promise((resolve) => setTimeout(resolve, contractTime));
+      return Math.random() * 1000 + 100;
+    }
+    async approve(address: string, usdc: number, options?: unknown) {
+      console.log('approve', { address, usdc, options });
+      return getMockContractReturn();
+    }
+  },
+  formatUnits(value: number, decimals: number | string) {
+    console.log('ethers.formatUnits', { value, decimals });
+    if (typeof decimals === 'string') {
+      return value.toFixed(2);
+    }
+
+    return value.toFixed(decimals);
+  },
+  isAddress(address: string) {
+    console.log('ethers.isAddress', address);
+    return true;
+  },
+  parseUnits(value: string, decimals: number) {
+    console.log('ethers.parseUnits', value, decimals);
+    return BigInt(parseFloat(value) * 10 ** decimals);
+  },
+};

--- a/lib/web3/adapter/dummy/index.ts
+++ b/lib/web3/adapter/dummy/index.ts
@@ -1,5 +1,6 @@
+'use client';
 import { IWeb3UseAuthHook } from '@/lib/web3/types';
-
+import { useEffect, useState } from 'react';
 /**
  * This is a very basic adapter
  * It may be used to access everything a anon web2-user can read
@@ -7,21 +8,55 @@ import { IWeb3UseAuthHook } from '@/lib/web3/types';
  */
 
 export { Web3ContextProvider, useWeb3Context } from './context-provider';
+import { useWeb3Context } from './context-provider';
 const staticAuth = {
   address: '0x0',
-  authenticated: false,
+  authenticated: true,
   ready: true,
   login: async () => {
     alert('dummy context only, switch in /lib/web3/adapter');
   },
   logout: async () => {},
 };
+export function getProvider() {
+  return {
+    request: async ({
+      method,
+      params,
+    }: {
+      method: string;
+      params: unknown[];
+    }) => {
+      console.log('provider.request', { method, params });
+      if (method === 'wallet_switchEthereumChain') {
+        window.dispatchEvent(
+          new CustomEvent('dummyChainId', {
+            detail: params[0],
+          }),
+        );
+      }
+    },
+    on: (event: string, callback: unknown) =>
+      console.log('provider.on', event, callback),
+    removeListener: (event: string, callback: unknown) =>
+      console.log('provider.removeListener', event, callback),
+  };
+}
 
 export function useAuth(): IWeb3UseAuthHook {
-  return staticAuth;
-}
-export function getProvider() {
-  return undefined;
+  const [wallet, setWallet] = useState();
+  const { initialized, address, requestWallet } = useWeb3Context();
+  useEffect(() => {
+    requestWallet().then((wallet) =>
+      setWallet({ ...wallet, getEthereumProvider: getProvider }),
+    );
+  }, [requestWallet]);
+  return {
+    ...staticAuth,
+    ready: initialized,
+    address,
+    wallet,
+  };
 }
 
 export * from './ethers';

--- a/lib/web3/adapter/dummy/wagmi.ts
+++ b/lib/web3/adapter/dummy/wagmi.ts
@@ -1,3 +1,4 @@
+import { useWeb3Context } from './context-provider';
 import { wagmiConfig, chainConfig } from './config';
 // wagmi/core  1837->2522 + 500ms
 // export { readContract, createConfig } from '@wagmi/core';
@@ -79,5 +80,7 @@ export function useConfig() {
   return wagmiConfig;
 }
 export function useChainId() {
-  return chainConfig.chainId;
+  const { chainId } = useWeb3Context();
+
+  return chainId;
 }

--- a/lib/web3/hooks/use-usdc-balance.ts
+++ b/lib/web3/hooks/use-usdc-balance.ts
@@ -4,15 +4,21 @@ import { USDC_ADDRESS } from '@/lib/constant';
 
 export function useUsdcBalance() {
   const { wallet } = useAuth();
-  const [usdcBalance, setUsdcBalance] = useState(0);
+  const [usdcBalance, setUsdcBalance] = useState('0.00');
+  const [isPending, setIsPending] = useState(true);
   useEffect(() => {
     const fetchUsdcBalance = async () => {
       console.log('fetchUSDCBalance');
+      setIsPending(true);
       if (!wallet || !(await wallet.isConnected())) {
+        setUsdcBalance('unknown (not connected)');
+        setIsPending(false);
         return;
       }
       const walletProvider = await wallet.getEthereumProvider();
       if (!walletProvider) {
+        setUsdcBalance('unknown (no wallet provider)');
+        setIsPending(false);
         return;
       }
       const ethersProvider = new ethers.BrowserProvider(walletProvider);
@@ -41,10 +47,11 @@ export function useUsdcBalance() {
         balance,
         unit,
       });
-      setUsdcBalance(parseFloat(ethers.formatUnits(balance, unit)));
+      setUsdcBalance(ethers.formatUnits(balance, unit));
+      setIsPending(false);
     };
 
     fetchUsdcBalance();
   }, [wallet]);
-  return usdcBalance;
+  return { usdcBalance, isPending };
 }

--- a/lib/web3/switch-network.ts
+++ b/lib/web3/switch-network.ts
@@ -13,9 +13,10 @@ export async function switchNetwork({ wallet }: { wallet: ConnectedWallet }) {
   }
   try {
     debug && console.log('Switching to Alfajores network...');
+    const chainIdHex = `0x${chainConfig.chainId.toString(16)}`;
     await walletProvider.request({
       method: 'wallet_switchEthereumChain',
-      params: [{ chainId: chainConfig.chainId.hex }],
+      params: [{ chainId: chainIdHex }],
     });
     debug && console.log('Successfully switched to Alfajores network');
   } catch (switchError: unknown) {

--- a/server/auth/providers/siwe.ts
+++ b/server/auth/providers/siwe.ts
@@ -40,6 +40,9 @@ export function SiweProvider() {
             'no nextAuthUrl (NEXTAUTH_URL,VERCEL_URL) - environment not configured correctly',
           );
         }
+        if (process.env.NODE_ENV === 'development') {
+          return await setupUser(credentials.message);
+        }
 
         const nextAuthHost = new URL(nextAuthUrl).host;
 


### PR DESCRIPTION
feat(donation): refactor donation form

- split into more components, separate wallet and stripe forms
  -> prepares for ccp tab
- move networkcheck and web3context down the tree, not every layout
  needs them
- fix switch-wallet-network: use ready state
- move web3 out of auth-context, wallet should be part of lib/web3
  -> redirects user to /api/auth/signin, needs to be updated to load siwe
     ui
- fix use-network-hook: checkNetwork relies on state that was changed with
  provider.request, refactor to change a state and react on state-change
- extend dummy-adapter to generate more elaborate web3 mock
- fix use-usd-balance-hook: add pending state
- allow siwe-login in development with any 'message' as user