### PR TITLE
feat(db): Extend Prisma Schema for Rounds, Contributions, and Feature Flags

### DIFF
--- a/prisma/migrations/20250913213231_enhance_models_cascade_delete_and_introduce_withdrawal_and_roundcontribution/migration.sql
+++ b/prisma/migrations/20250913213231_enhance_models_cascade_delete_and_introduce_withdrawal_and_roundcontribution/migration.sql
@@ -1,0 +1,159 @@
+-- CreateEnum
+CREATE TYPE "PaymentRefundState" AS ENUM ('NONE', 'REQUESTED', 'PROCESSED', 'APPROVED');
+
+-- CreateEnum
+CREATE TYPE "MediaState" AS ENUM ('CREATED', 'UPLOADED', 'BLOCKED');
+
+-- CreateEnum
+CREATE TYPE "WithdrawState" AS ENUM ('REQUESTED', 'APPROVED', 'REJECTED', 'EXECUTED');
+
+-- DropForeignKey
+ALTER TABLE "CampaignCollection" DROP CONSTRAINT "CampaignCollection_campaignId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CampaignCollection" DROP CONSTRAINT "CampaignCollection_collectionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CampaignImage" DROP CONSTRAINT "CampaignImage_campaignId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Collection" DROP CONSTRAINT "Collection_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Comment" DROP CONSTRAINT "Comment_campaignId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Payment" DROP CONSTRAINT "Payment_campaignId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Payment" DROP CONSTRAINT "Payment_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PaymentMethod" DROP CONSTRAINT "PaymentMethod_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RoundCampaigns" DROP CONSTRAINT "RoundCampaigns_campaignId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RoundCampaigns" DROP CONSTRAINT "RoundCampaigns_roundId_fkey";
+
+-- AlterTable
+ALTER TABLE "Campaign" ADD COLUMN     "mediaOrder" INTEGER[];
+
+-- AlterTable
+ALTER TABLE "CampaignUpdate" ADD COLUMN     "mediaOrder" INTEGER[];
+
+-- AlterTable
+ALTER TABLE "Payment" ADD COLUMN     "refundState" "PaymentRefundState" NOT NULL DEFAULT 'NONE';
+
+-- AlterTable
+ALTER TABLE "Round" ADD COLUMN     "approvedResult" JSONB,
+ADD COLUMN     "descriptionUrl" TEXT,
+ADD COLUMN     "fundWalletAddress" TEXT,
+ADD COLUMN     "mediaOrder" INTEGER[];
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "featureFlags" TEXT[];
+
+-- CreateTable
+CREATE TABLE "Media" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" INTEGER,
+    "state" "MediaState" NOT NULL DEFAULT 'CREATED',
+    "url" TEXT NOT NULL,
+    "caption" TEXT,
+    "mimeType" TEXT NOT NULL,
+    "campaignId" INTEGER,
+    "updateId" INTEGER,
+    "roundId" INTEGER,
+
+    CONSTRAINT "Media_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoundContribution" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "campaignId" INTEGER NOT NULL,
+    "roundCampaignId" INTEGER NOT NULL,
+    "paymentId" INTEGER NOT NULL,
+    "humanityScore" INTEGER NOT NULL,
+
+    CONSTRAINT "RoundContribution_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Withdrawal" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" INTEGER NOT NULL,
+    "approvedById" INTEGER NOT NULL,
+    "amount" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "notes" TEXT,
+    "transactionHash" TEXT,
+    "campaignId" INTEGER NOT NULL,
+
+    CONSTRAINT "Withdrawal_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "CampaignImage" ADD CONSTRAINT "CampaignImage_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Media" ADD CONSTRAINT "Media_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Media" ADD CONSTRAINT "Media_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Media" ADD CONSTRAINT "Media_updateId_fkey" FOREIGN KEY ("updateId") REFERENCES "CampaignUpdate"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Media" ADD CONSTRAINT "Media_roundId_fkey" FOREIGN KEY ("roundId") REFERENCES "Round"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PaymentMethod" ADD CONSTRAINT "PaymentMethod_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoundCampaigns" ADD CONSTRAINT "RoundCampaigns_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoundCampaigns" ADD CONSTRAINT "RoundCampaigns_roundId_fkey" FOREIGN KEY ("roundId") REFERENCES "Round"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Collection" ADD CONSTRAINT "Collection_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("address") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CampaignCollection" ADD CONSTRAINT "CampaignCollection_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CampaignCollection" ADD CONSTRAINT "CampaignCollection_collectionId_fkey" FOREIGN KEY ("collectionId") REFERENCES "Collection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoundContribution" ADD CONSTRAINT "RoundContribution_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoundContribution" ADD CONSTRAINT "RoundContribution_roundCampaignId_fkey" FOREIGN KEY ("roundCampaignId") REFERENCES "RoundCampaigns"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoundContribution" ADD CONSTRAINT "RoundContribution_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "Payment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Withdrawal" ADD CONSTRAINT "Withdrawal_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Withdrawal" ADD CONSTRAINT "Withdrawal_approvedById_fkey" FOREIGN KEY ("approvedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Withdrawal" ADD CONSTRAINT "Withdrawal_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,12 @@ enum PaymentType {
   SELL
 }
 
-
+enum PaymentRefundState {
+  NONE
+  REQUESTED
+  PROCESSED
+  APPROVED
+}
 
 enum RecipientStatus {
   PENDING
@@ -36,7 +41,18 @@ enum Status {
   CLOSED
 }
 
+enum MediaState {
+  CREATED
+  UPLOADED
+  BLOCKED
+}
 
+enum WithdrawState {
+  REQUESTED
+  APPROVED
+  REJECTED
+  EXECUTED
+}
 
 model Campaign {
   id              Int                  @id @default(autoincrement())
@@ -52,9 +68,9 @@ model Campaign {
   updatedAt       DateTime             @updatedAt
   campaignAddress String?              @unique
   slug            String               @unique
-  location              String?
-  treasuryAddress       String?
-  category              String?
+  location        String?
+  treasuryAddress String?
+  category        String?
   collections     CampaignCollection[]
   images          CampaignImage[]
   updates         CampaignUpdate[]
@@ -63,16 +79,40 @@ model Campaign {
   payments        Payment[]
   RoundCampaigns  RoundCampaigns[]
 
+  roundContributions RoundContribution[]
+  withdrawals        Withdrawal[]
+  media              Media[]
+  mediaOrder         Int[]
+
   @@index([creatorAddress])
   @@index([category])
 }
 
+// deprecated
 model CampaignImage {
   id          Int      @id @default(autoincrement())
   imageUrl    String
   isMainImage Boolean  @default(false)
   campaignId  Int
-  campaign    Campaign @relation(fields: [campaignId], references: [id])
+  campaign    Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+}
+
+model Media {
+  id          String     @id @default(uuid())
+  createdAt   DateTime   @default(now())
+  createdBy   User?      @relation(name: "MediaCreatedBy", fields: [createdById], references: [id])
+  createdById Int?
+  state       MediaState @default(CREATED)
+  url         String
+  caption     String?
+  mimeType    String
+
+  campaignId Int?
+  campaign   Campaign?       @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  updateId   Int?
+  update     CampaignUpdate? @relation(fields: [updateId], references: [id], onDelete: Cascade)
+  roundId    Int?
+  round      Round?          @relation(fields: [roundId], references: [id], onDelete: Cascade)
 }
 
 model User {
@@ -84,6 +124,7 @@ model User {
   lastSigninAt         DateTime?
   lastSignoutAt        DateTime?
   roles                String[]
+  featureFlags         String[]
   crowdsplitCustomerId String?
   email                String?
   username             String?         @unique
@@ -95,25 +136,32 @@ model User {
   collections          Collection[]
   payments             Payment[]
   paymentMethods       PaymentMethod[]
+  createdMedia         Media[]         @relation(name: "MediaCreatedBy")
+
+  withdrawals Withdrawal[] @relation(name: "WithdrawalCreatedBy")
+  approvals   Withdrawal[] @relation(name: "WithdrawalApprovedBy")
 }
 
 model Payment {
-  id              Int         @id @default(autoincrement())
+  id              Int                @id @default(autoincrement())
   amount          String
   token           String
-  status          String      @default("pending")
+  status          String             @default("pending")
   type            PaymentType
   transactionHash String?
-  isAnonymous     Boolean     @default(false)
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
+  isAnonymous     Boolean            @default(false)
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
   campaignId      Int
   userId          Int
   externalId      String?
   metadata        Json?
   provider        String?
-  campaign        Campaign    @relation(fields: [campaignId], references: [id])
-  user            User        @relation(fields: [userId], references: [id])
+  refundState     PaymentRefundState @default(NONE)
+  campaign        Campaign           @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  user            User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  RoundContribution RoundContribution[]
 
   @@index([campaignId])
   @@index([userId])
@@ -128,7 +176,7 @@ model PaymentMethod {
   userId     Int
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
-  user       User     @relation(fields: [userId], references: [id])
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([externalId])
@@ -141,7 +189,7 @@ model Comment {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   campaignId  Int
-  campaign    Campaign @relation(fields: [campaignId], references: [id])
+  campaign    Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
 
   @@index([campaignId])
   @@index([userAddress])
@@ -156,27 +204,34 @@ model CampaignUpdate {
   campaignId     Int
   creatorAddress String
   campaign       Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  media          Media[]
+  mediaOrder     Int[]
 
   @@index([campaignId])
 }
 
 model Round {
-  id               Int              @id @default(autoincrement())
-  title            String
-  description      String
-  tags             String[]         @default([])
-  matchingPool     Decimal
-  applicationStart DateTime
-  applicationClose DateTime
-  startDate        DateTime
-  endDate          DateTime
-  blockchain       String
-  logoUrl          String?
-  createdAt        DateTime         @default(now())
-  managerAddress   String
-  poolId           BigInt?          @unique
-  updatedAt        DateTime         @updatedAt
-  roundCampaigns   RoundCampaigns[]
+  id                Int              @id @default(autoincrement())
+  title             String
+  description       String
+  descriptionUrl    String?
+  tags              String[]         @default([])
+  matchingPool      Decimal
+  applicationStart  DateTime
+  applicationClose  DateTime
+  startDate         DateTime
+  endDate           DateTime
+  blockchain        String
+  logoUrl           String? // deprecated
+  createdAt         DateTime         @default(now())
+  managerAddress    String
+  fundWalletAddress String?
+  poolId            BigInt?          @unique
+  updatedAt         DateTime         @updatedAt
+  roundCampaigns    RoundCampaigns[]
+  media             Media[]
+  mediaOrder        Int[]
+  approvedResult    Json?
 }
 
 model RoundCampaigns {
@@ -191,8 +246,10 @@ model RoundCampaigns {
   submittedByWalletAddress String?
   txHash                   String?
   status                   RecipientStatus @default(PENDING)
-  Campaign                 Campaign        @relation(fields: [campaignId], references: [id])
-  Round                    Round           @relation(fields: [roundId], references: [id])
+  Campaign                 Campaign        @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  Round                    Round           @relation(fields: [roundId], references: [id], onDelete: Cascade)
+
+  roundContributions RoundContribution[]
 
   @@unique([roundId, campaignId])
 }
@@ -206,7 +263,7 @@ model Collection {
   // this should be called userAddress
   userId      String
   campaigns   CampaignCollection[]
-  user        User                 @relation(fields: [userId], references: [address])
+  user        User                 @relation(fields: [userId], references: [address], onDelete: Cascade)
 
   @@unique([userId, name])
   @@index([userId])
@@ -216,8 +273,8 @@ model CampaignCollection {
   campaignId   Int
   collectionId String
   assignedAt   DateTime   @default(now())
-  campaign     Campaign   @relation(fields: [campaignId], references: [id])
-  collection   Collection @relation(fields: [collectionId], references: [id])
+  campaign     Campaign   @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  collection   Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
 
   @@id([campaignId, collectionId])
 }
@@ -232,4 +289,32 @@ model Favorite {
   @@unique([userAddress, campaignId])
   @@index([userAddress])
   @@index([campaignId])
+}
+
+model RoundContribution {
+  id              Int            @id @default(autoincrement())
+  createdAt       DateTime       @default(now())
+  campaign        Campaign       @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  campaignId      Int
+  roundCampaign   RoundCampaigns @relation(fields: [roundCampaignId], references: [id], onDelete: Cascade)
+  roundCampaignId Int
+  payment         Payment        @relation(fields: [paymentId], references: [id], onDelete: Cascade)
+  paymentId       Int
+  humanityScore   Int
+}
+
+model Withdrawal {
+  id              Int      @id @default(autoincrement())
+  createdAt       DateTime @default(now())
+  createdBy       User     @relation(name: "WithdrawalCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
+  createdById     Int
+  approvedBy      User     @relation(name: "WithdrawalApprovedBy", fields: [approvedById], references: [id])
+  approvedById    Int
+  amount          String
+  token           String
+  notes           String?
+  transactionHash String?
+
+  campaign   Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  campaignId Int
 }


### PR DESCRIPTION
closes #174

Create models
 - Media (deprecating CampaignImage/Round.logoUrl)
 - Withdrawal
 - RoundContribution

Correct Model
 - Cascade Delete

Extend Model
  - Payment refund state
  - User feature flags
  - Round approvedResult and descriptionUrl

Extend Seed
  - Rounds
  - Round Campaigns
  - Admin/Donor/Creator users