### PR TITLE
fix(api): admins can just disable campaigns

### DIFF
--- a/app/api/campaigns/[campaignId]/disable/route.ts
+++ b/app/api/campaigns/[campaignId]/disable/route.ts
@@ -44,12 +44,15 @@ export async function POST(req: Request, { params }: CampaignsWithIdParams) {
       throw new ApiNotFoundError('Campaign Creator not found');
     }
 
-    // Determine the appropriate status based on who is disabling
+    // Determine the appropriate status based on who is disabling and campaign state
     let newStatus: CampaignStatus;
 
     if (isAdmin) {
-      // Admin disabling: requires re-approval
-      newStatus = CampaignStatus.PENDING_APPROVAL;
+      // Admin disabling: if campaign has treasury address, just disable it (can be re-enabled)
+      // If no treasury address, it requires re-approval
+      newStatus = campaign.treasuryAddress
+        ? CampaignStatus.DISABLED
+        : CampaignStatus.PENDING_APPROVAL;
     } else {
       // Owner disabling their own campaign: mark as disabled (can be re-enabled)
       newStatus = CampaignStatus.DISABLED;


### PR DESCRIPTION
This solves when an admin was disabling an active campaign, that it would be switched back to pending approval state, while when it is in the past (already begung) approval is disabled, so there was no pay to re-activate. 