### PR TITLE
feat(dev): github action for automated version bumping

### DIFF
--- a/.github/workflows/auto-version-bump-on-staging.yml
+++ b/.github/workflows/auto-version-bump-on-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   version_bump:
-    if: github.event.head_commit.message == 'Merge pull request' # Only run on actual merge commits
+    if: startsWith(github.event.head_commit.message, 'Merge pull request') # Only run on actual merge commits
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -15,10 +15,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: staging  # Checkout the staging branch
+          ref: staging # Checkout the staging branch
           fetch-depth: 0
+
+      - name: Merge main into staging
+        run: |
+          git merge origin/main --no-edit
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -63,13 +67,13 @@ jobs:
 
       - name: Push changes to staging
         run: git push origin staging
-
       - name: Create Pull Request to main
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Release ${{ steps.get_version.outputs.NEW_VERSION }}"
-          body: "Automated release pull request after merging to main."
-          head: staging
-          base: main
-          commit-message: "chore(release): Create release PR"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head staging \
+            --title "Release ${{ steps.get_version.outputs.NEW_VERSION }}" \
+            --body "Automated release pull request after merging to main." || \
+          echo "PR already exists or creation failed"

--- a/increase-version
+++ b/increase-version
@@ -80,20 +80,21 @@ check_jq_installed
 VERSION_TYPE="patch"
 
 # Parse command-line arguments
-for arg in "$@"
-do
-    case "$arg" in
+if [ $# -gt 1 ]; then
+    echo "Error: Only one version bump type can be specified."
+    usage
+fi
+
+if [ $# -eq 1 ]; then
+    case "$1" in
         --major)
             VERSION_TYPE="major"
-            shift
             ;;
         --minor)
             VERSION_TYPE="minor"
-            shift
             ;;
         --patch)
             VERSION_TYPE="patch"
-            shift
             ;;
         *)
             usage
@@ -145,12 +146,17 @@ read -p "Review the changes above. Press Enter to continue with the commit, or C
 git add "${PACKAGE_JSON_PATH}"
 git commit -m "Release ${new_version}"
 
+echo "Pushing version bump to origin/${BRANCH_TO_UPDATE}..."
+git push origin "${BRANCH_TO_UPDATE}"
+
 echo "Version bump and commit successful."
 
 # 8. Unstash changes if any were stashed
-if git stash list | grep -q "Pre-version-bump stash"; then
+if git stash list | head -1 | grep -q "Pre-version-bump stash"; then
     echo "Unstashing previous changes..."
     git stash pop
+else
+    echo "No stashed changes to restore."
 fi
 
 echo "Script finished."


### PR DESCRIPTION
on release we can still decide if a minor or major bump is required

this way we always have a staging->main PR

also adds a cli that devs can run locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with automated version management and improved release coordination tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->