### PR TITLE
Fix auth email

### DIFF
--- a/lib/web3/adapter/appkit/config.ts
+++ b/lib/web3/adapter/appkit/config.ts
@@ -109,7 +109,6 @@ export const siweConfig = createSIWEConfig({
   verifyMessage: async ({ message, signature }: SIWEVerifyMessageArgs) => {
     try {
       const session = await getSession();
-      if(session.user){
       if(session?.user){
         return true;
       }


### PR DESCRIPTION
Avoid re-signin when auth0 already has a session

- works on preview deployment, but has troubles with donate via wallet (CSP to forno.celo-testnet triggered by embedded wallet). unsure if this also happens with NON-testnet