### PR TITLE
fix: users can donate again

### DIFF
--- a/components/campaign/donation/daimo-tab.tsx
+++ b/components/campaign/donation/daimo-tab.tsx
@@ -25,6 +25,7 @@ export function DaimoPayTab({ campaign }: { campaign: DbCampaign }) {
     setIsProcessingPayment,
     setIsPaymentCompleted,
     clearDonation,
+    setAmount,
   } = useDonationContext();
 
   useEffect(() => {
@@ -40,7 +41,8 @@ export function DaimoPayTab({ campaign }: { campaign: DbCampaign }) {
   const handlePaymentCompleted = useCallback(() => {
     setIsProcessingPayment(false);
     setIsPaymentCompleted(true);
-  }, [setIsProcessingPayment, setIsPaymentCompleted]);
+    setAmount('0');
+  }, [setIsProcessingPayment, setIsPaymentCompleted, setAmount]);
 
   const handlePaymentBounced = useCallback(() => {
     setIsProcessingPayment(false);
@@ -51,10 +53,10 @@ export function DaimoPayTab({ campaign }: { campaign: DbCampaign }) {
     router.push(`/campaigns/${campaign.slug}`);
   }, [router, campaign.slug]);
 
-  const handleDonateAgain = useCallback(() => {
-    setIsPaymentCompleted(false);
-    setIsProcessingPayment(false);
-  }, [setIsPaymentCompleted, setIsProcessingPayment]);
+  // const handleDonateAgain = useCallback(() => {
+  //   setIsPaymentCompleted(false);
+  //   setIsProcessingPayment(false);
+  // }, [setIsPaymentCompleted, setIsProcessingPayment]);
 
   return (
     <DaimoPayProvider theme="auto">
@@ -76,9 +78,9 @@ export function DaimoPayTab({ campaign }: { campaign: DbCampaign }) {
               <Button onClick={handleViewCampaign} variant="default">
                 View Campaign
               </Button>
-              <Button onClick={handleDonateAgain} variant="outline">
+              {/* <Button onClick={handleDonateAgain} variant="outline">
                 Donate Again
-              </Button>
+              </Button> */}
             </div>
           </div>
         )}


### PR DESCRIPTION
- this is not an actual fix, we are removing the button for now
- I also set amount to 0 on success payment.

I believe that the issue lies there, because when the user changes the input value after clicking on donate again, the banner appears again because DaimoButton gets rerendered and it seems it triggers onPaymentCompletedCallback again.
Then if the user makes another contribution, the callback is not called, I believe that's why the banner doesn't appear again, and also why there was an amount mismatch in the payments.

All this is just a theory as it is not possible to test in development.

But I try to change the amount twice between clicking the donate button again and making the 2nd contribution and it worked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed donation amount field to reset after successful payment completion.
  * Removed "Donate Again" button from the post-payment success screen to streamline the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->