### PR TITLE
add 4MB file size validation for campaign banner images

### DIFF
--- a/components/campaign/constants.ts
+++ b/components/campaign/constants.ts
@@ -1,0 +1,5 @@
+// ABOUTME: Shared constants for campaign form validation.
+// ABOUTME: Contains file size limits and error messages for banner images.
+
+export const MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024; // 4MB
+export const FILE_SIZE_ERROR_MESSAGE = 'Image must be smaller than 4MB';

--- a/components/campaign/create/form-media.tsx
+++ b/components/campaign/create/form-media.tsx
@@ -10,8 +10,10 @@ import {
   Button,
 } from '@/components/ui';
 import Image from 'next/image';
-
-const MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024; // 4MB
+import {
+  MAX_FILE_SIZE_BYTES,
+  FILE_SIZE_ERROR_MESSAGE,
+} from '@/components/campaign/constants';
 
 export function CampaignCreateFormMedia() {
   const form = useFormContext();
@@ -32,7 +34,7 @@ export function CampaignCreateFormMedia() {
       const file = event.target.files?.[0] || null;
       if (file && file.size > MAX_FILE_SIZE_BYTES) {
         form.setError('bannerImage', {
-          message: 'Image must be smaller than 4MB',
+          message: FILE_SIZE_ERROR_MESSAGE,
         });
         event.target.value = '';
         return;

--- a/components/campaign/create/form.ts
+++ b/components/campaign/create/form.ts
@@ -6,6 +6,10 @@ import {
   FUNDING_USAGE_MAX_LENGTH,
   FUNDING_USAGE_MIN_LENGTH,
 } from '@/lib/constant/form';
+import {
+  MAX_FILE_SIZE_BYTES,
+  FILE_SIZE_ERROR_MESSAGE,
+} from '@/components/campaign/constants';
 import type { DbCampaign } from '@/types/campaign';
 import {
   ValidationStage,
@@ -166,8 +170,8 @@ export const CampaignFormSchema = z
     bannerImage: z
       .instanceof(File)
       .refine(
-        (file) => file.size <= 4 * 1024 * 1024,
-        'Image must be smaller than 4MB',
+        (file) => file.size <= MAX_FILE_SIZE_BYTES,
+        FILE_SIZE_ERROR_MESSAGE,
       )
       .or(z.null())
       .optional(),

--- a/components/campaign/edit/form-media.tsx
+++ b/components/campaign/edit/form-media.tsx
@@ -11,8 +11,10 @@ import {
 } from '@/components/ui';
 import { DbCampaign } from '@/types/campaign';
 import Image from 'next/image';
-
-const MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024; // 4MB
+import {
+  MAX_FILE_SIZE_BYTES,
+  FILE_SIZE_ERROR_MESSAGE,
+} from '@/components/campaign/constants';
 
 export function CampaignEditFormMedia({ campaign }: { campaign?: DbCampaign }) {
   const form = useFormContext();
@@ -70,7 +72,7 @@ export function CampaignEditFormMedia({ campaign }: { campaign?: DbCampaign }) {
                   const file = event.target.files?.[0] || null;
                   if (file && file.size > MAX_FILE_SIZE_BYTES) {
                     form.setError('bannerImage', {
-                      message: 'Image must be smaller than 4MB',
+                      message: FILE_SIZE_ERROR_MESSAGE,
                     });
                     event.target.value = '';
                     return;

--- a/components/campaign/edit/form.ts
+++ b/components/campaign/edit/form.ts
@@ -5,6 +5,10 @@ import {
   FUNDING_USAGE_MIN_LENGTH,
 } from '@/lib/constant/form';
 import { validateAndParseDateString } from '@/lib/utils/date';
+import {
+  MAX_FILE_SIZE_BYTES,
+  FILE_SIZE_ERROR_MESSAGE,
+} from '@/components/campaign/constants';
 
 function validateTimes(value: string) {
   const date = new Date(value);
@@ -96,8 +100,8 @@ export const CampaignFormSchema = z
     bannerImage: z
       .instanceof(File)
       .refine(
-        (file) => file.size <= 4 * 1024 * 1024,
-        'Image must be smaller than 4MB',
+        (file) => file.size <= MAX_FILE_SIZE_BYTES,
+        FILE_SIZE_ERROR_MESSAGE,
       )
       .or(z.null())
       .optional(),


### PR DESCRIPTION
Fixes HTTP 413 errors when users upload large images that exceed Vercel's serverless function body size limit. Validation happens both client-side (immediate feedback) and in Zod schema.