### PR TITLE
fix: show upcoming rounds on homepage after applications close

### DIFF
--- a/components/home/round-spotlight.tsx
+++ b/components/home/round-spotlight.tsx
@@ -55,6 +55,22 @@ export function RoundSpotlight() {
     );
   }, [round?.startTime, isUpcoming]);
 
+  // Check if applications are still open
+  const applicationsOpen = useMemo(() => {
+    if (!round?.applicationEndTime) {
+      return false;
+    }
+    return new Date(round.applicationEndTime) > new Date();
+  }, [round?.applicationEndTime]);
+
+  // Format application end date
+  const applicationEndDate = useMemo(() => {
+    if (!round?.applicationEndTime) {
+      return '';
+    }
+    return new Date(round.applicationEndTime).toLocaleDateString();
+  }, [round?.applicationEndTime]);
+
   // Don't render anything if there's no round or if loading/error
   if (isLoading || error || !round) {
     return null;
@@ -150,12 +166,19 @@ export function RoundSpotlight() {
             <div className="mb-4 rounded-lg border border-border bg-muted p-3">
               <p className="text-sm text-muted-foreground">
                 {isUpcoming ? (
-                  <>
-                    <strong>📅 Coming Soon:</strong> This round will feature{' '}
-                    {formatUSD(round.matchingPool)} in matching funds for
-                    approved campaigns. Applications are currently being
-                    reviewed.
-                  </>
+                  applicationsOpen ? (
+                    <>
+                      <strong>📅 Coming Soon:</strong> This round will feature{' '}
+                      {formatUSD(round.matchingPool)} in matching funds.
+                      Applications are open until {applicationEndDate}.
+                    </>
+                  ) : (
+                    <>
+                      <strong>📅 Coming Soon:</strong> This round will feature{' '}
+                      {formatUSD(round.matchingPool)} in matching funds for
+                      approved campaigns. Applications are now closed.
+                    </>
+                  )
                 ) : (
                   <>
                     <strong>💡 Match Funding:</strong> Your donation gets

--- a/lib/api/rounds.ts
+++ b/lib/api/rounds.ts
@@ -404,7 +404,7 @@ export async function getUpcomingRound() {
   const upcomingRound = await db.round.findFirst({
     where: {
       isHidden: false, // Exclude hidden rounds
-      applicationClose: {
+      startDate: {
         gt: now, // Round hasn't started yet
       },
     },


### PR DESCRIPTION
The homepage round spotlight was not showing rounds in the gap between application close and round start. Fixed by using startDate instead of applicationClose to determine upcoming rounds. Also updated the messaging to show correct application status (open with date vs closed).