### PR TITLE
debug(cron): add logging to diagnose CRON_SECRET issue

### DIFF
--- a/app/api/cron/reprocess-daimo-webhooks/route.ts
+++ b/app/api/cron/reprocess-daimo-webhooks/route.ts
@@ -22,6 +22,15 @@ export async function GET(request: Request) {
     const authHeader = request.headers.get('authorization');
     const cronSecret = process.env.CRON_SECRET;
 
+    // Debug logging to diagnose env var issue
+    logInfo('Cron auth debug', {
+      hasCronSecret: !!cronSecret,
+      cronSecretLength: cronSecret?.length ?? 0,
+      cronSecretPrefix: cronSecret?.substring(0, 4) ?? 'N/A',
+      hasAuthHeader: !!authHeader,
+      authHeaderPrefix: authHeader?.substring(0, 10) ?? 'N/A',
+    });
+
     if (!cronSecret) {
       logError('CRON_SECRET environment variable is not configured');
       throw new ApiAuthNotAllowed('Cron endpoint not configured');


### PR DESCRIPTION
Logs whether env var exists, its length, and prefix to help debug why the cron endpoint reports "not configured" despite the env var being set in Vercel dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging for debugging purposes in the cron API handler to provide better visibility into system state during operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->