### PR TITLE
Honor content_editor role in campaign update UI

### DIFF
--- a/components/campaign/detail-tab-updates.tsx
+++ b/components/campaign/detail-tab-updates.tsx
@@ -14,7 +14,7 @@ export function CampaignDetailTabUpdates({
   campaign: DbCampaign;
 }) {
   const { ref, inView } = useInView();
-  const { address } = useAuth();
+  const { address, isContentEditor } = useAuth();
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
   const {
     data,
@@ -29,6 +29,7 @@ export function CampaignDetailTabUpdates({
     address &&
     campaign.creatorAddress &&
     address.toLowerCase() === campaign.creatorAddress.toLowerCase();
+  const canPost = Boolean(isOwner) || isContentEditor;
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
@@ -71,7 +72,7 @@ export function CampaignDetailTabUpdates({
         </div>
       ) : updates.length > 0 ? (
         <>
-          {isOwner && (
+          {canPost && (
             <div className="flex justify-start">
               <Button
                 onClick={() => setIsUpdateModalOpen(true)}
@@ -112,7 +113,7 @@ export function CampaignDetailTabUpdates({
           <p className="text-sm text-muted-foreground">
             Check back later for updates on this campaign&apos;s progress.
           </p>
-          {isOwner && (
+          {canPost && (
             <div className="mt-6">
               <Button
                 onClick={() => setIsUpdateModalOpen(true)}
@@ -128,7 +129,7 @@ export function CampaignDetailTabUpdates({
 
       {!error && <div ref={ref} className="h-10" />}
 
-      {isOwner && (
+      {canPost && (
         <CampaignUpdateModal
           campaign={campaign}
           open={isUpdateModalOpen}

--- a/components/campaign/update-form.tsx
+++ b/components/campaign/update-form.tsx
@@ -48,7 +48,7 @@ export function CampaignUpdateForm({
   const { toast } = useToast();
   const { mutateAsync: createCampaignUpdate, isPending } =
     useCreateCampaignUpdate();
-  const { address: userAddress } = useAuth();
+  const { address: userAddress, isContentEditor } = useAuth();
 
   const form = useForm<CampaignUpdateFormValues>({
     resolver: zodResolver(campaignUpdateFormSchema),
@@ -60,8 +60,9 @@ export function CampaignUpdateForm({
   });
 
   const isOwner = userAddress === creatorAddress;
+  const canPost = isOwner || isContentEditor;
 
-  if (!isOwner) {
+  if (!canPost) {
     return null;
   }
 

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -16,6 +16,8 @@ interface AuthContextType {
   address?: string;
   authenticated: boolean;
   isAdmin: boolean;
+  isContentEditor: boolean;
+  roles: string[];
   isClient: boolean;
   isReady: boolean;
   login: () => void;
@@ -26,6 +28,8 @@ const AuthContext = createContext<AuthContextType>({
   address: undefined,
   authenticated: false,
   isAdmin: false,
+  isContentEditor: false,
+  roles: [],
   isClient: false,
   isReady: false,
   login: () => {},
@@ -80,9 +84,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     setIsClient(true);
   }, []);
 
-  const isAdmin = useMemo(() => {
-    return session?.data?.user?.roles?.includes('admin') ?? false;
+  const roles = useMemo(() => {
+    return session?.data?.user?.roles ?? [];
   }, [session?.data?.user?.roles]);
+
+  const isAdmin = useMemo(() => {
+    return roles.includes('admin');
+  }, [roles]);
+
+  const isContentEditor = useMemo(() => {
+    return roles.includes('content_editor');
+  }, [roles]);
   // Debugging logs
   useEffect(() => {
     if (!isClient || !debug) {
@@ -113,11 +125,22 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       authenticated,
       isReady,
       isAdmin,
+      isContentEditor,
+      roles,
       isClient,
       login: signIn,
       logout,
     };
-  }, [address, authenticated, isReady, isAdmin, isClient, logout]);
+  }, [
+    address,
+    authenticated,
+    isReady,
+    isAdmin,
+    isContentEditor,
+    roles,
+    isClient,
+    logout,
+  ]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };


### PR DESCRIPTION
## Problem

A user granted the `content_editor` role (e.g. Joëlle @ Refunite) couldn't post campaign updates through the UI. The backend already authorizes content editors to post/edit updates (`app/api/campaigns/[campaignId]/updates/route.ts` checks `content_editor`), but the **frontend only ever rendered the "Post Update" form and buttons to the campaign creator** — so a content editor never had any control to click, and no POST request was ever made (confirmed via prod logs: only `GET /api/auth/session`, zero update POSTs).

## Fix

- **`contexts/AuthContext.tsx`** — derive and expose `isContentEditor` and `roles` from the session (previously only `isAdmin` was available client-side).
- **`components/campaign/update-form.tsx`** — render the form for `isOwner || isContentEditor` instead of owner-only.
- **`components/campaign/detail-tab-updates.tsx`** — gate the "Post Update" buttons and the update modal on `canPost` (owner **or** content editor).

No backend changes — this just unblocks the UI so the already-permitted request can be made. The `CampaignUpdateModal` delegates to the form, so it's covered by the same gate.

## ⚠️ Re-login required

Roles are baked into the NextAuth JWT at login and only refresh ~daily (`server/auth/jwt.ts`). After this deploys, a freshly granted content editor must **log out and back in once** before the role shows up in their session and the new UI gate lets them in.

## Out of scope

The campaign **edit** page (`app/campaigns/[slug]/edit/page.tsx:29`) is still creator/admin-only and does not honor `content_editor`. Left untouched to keep this PR scoped to the reported updates flow — can follow up if content editors should also edit campaign metadata via the UI.

## Validation

Run in the app container (Colima):
- `tsc --noEmit` — clean
- ESLint (changed files) — clean
- Prettier (changed files) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content editor role introduced: A new content editor role enables designated users to post campaign updates and manage campaign content independently. Content editors can now view and use posting controls without being the campaign creator, improving team collaboration, enabling shared responsibilities, and providing more flexible campaign management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->