### PR TITLE
Fix 12 failing tests + reject PAUSED/CANCELLED campaigns in validation

### DIFF
--- a/lib/api/auth.test.ts
+++ b/lib/api/auth.test.ts
@@ -7,6 +7,11 @@ import { Session } from 'next-auth';
 vi.mock('@/server/auth', () => ({
   auth: vi.fn(),
 }));
+// checkAuth confirms the session's user exists in the DB (Web3 principle:
+// valid session = valid user). Mock that lookup so it resolves without a DB.
+vi.mock('./user', () => ({
+  getUser: vi.fn(async () => ({ id: 0, address: '0x0', roles: [] })),
+}));
 function mockSession(roles: string[]) {
   return {
     user: { dbId: 0, address: '0x0', roles },

--- a/lib/api/qf/get-qf-campaign-matching.test.ts
+++ b/lib/api/qf/get-qf-campaign-matching.test.ts
@@ -63,7 +63,7 @@ describe('getQfCampaignMatching', () => {
         ApiParameterError,
       );
       await expect(getQfCampaignMatching(1, 999)).rejects.toThrow(
-        'Campaign matching amount not found',
+        'Campaign 999 not found in round 1 distribution',
       );
     });
   });

--- a/lib/ccp-validation/campaign-validation.ts
+++ b/lib/ccp-validation/campaign-validation.ts
@@ -120,6 +120,28 @@ export const CAMPAIGN_VALIDATION_RULES: ValidationRule[] = [
     prevention: 'Prevents operations on failed campaigns',
   },
 
+  {
+    id: 'campaign-paused',
+    stage: ValidationStage.ACTIVE,
+    severity: ValidationSeverity.ERROR,
+    contractError: 'PausedError',
+    condition: (campaign) => campaign.status === 'PAUSED',
+    message: 'Campaign is currently paused',
+    userMessage: 'Cannot perform operations on a paused campaign.',
+    prevention: 'Prevents operations on paused campaigns',
+  },
+
+  {
+    id: 'campaign-cancelled',
+    stage: ValidationStage.ACTIVE,
+    severity: ValidationSeverity.ERROR,
+    contractError: 'CancelledError',
+    condition: (campaign) => campaign.status === 'CANCELLED',
+    message: 'Campaign has been cancelled',
+    userMessage: 'Cannot perform operations on a cancelled campaign.',
+    prevention: 'Prevents operations on cancelled campaigns',
+  },
+
   // ========== CONTRACT DEPLOYMENT VALIDATION ==========
   {
     id: 'campaign-contract-missing',

--- a/lib/utils/metadata.test.ts
+++ b/lib/utils/metadata.test.ts
@@ -2,19 +2,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getBaseUrl } from './metadata';
 
 describe('getBaseUrl', () => {
-  const originalEnv = process.env;
-
   beforeEach(() => {
-    // Reset environment variables before each test
-    vi.stubEnv('NODE_ENV', originalEnv.NODE_ENV);
-    vi.stubEnv('VERCEL_URL', originalEnv.VERCEL_URL);
-    vi.stubEnv('NEXT_PUBLIC_SITE_URL', originalEnv.NEXT_PUBLIC_SITE_URL);
-    vi.stubEnv('NEXT_PUBLIC_ENVIRONMENT', originalEnv.NEXT_PUBLIC_ENVIRONMENT);
+    // Start each test from a clean, deterministic env. Clearing the URL-related
+    // vars (rather than copying from a live process.env reference) prevents one
+    // test's stubbed value — e.g. VERCEL_URL — from leaking into the next.
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('VERCEL_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_ENVIRONMENT', '');
   });
 
   afterEach(() => {
-    // Restore original environment after each test
-    vi.restoreAllMocks();
+    // Remove all env stubs so nothing carries over between tests.
+    vi.unstubAllEnvs();
   });
 
   it('should return Vercel URL when VERCEL_URL is set', () => {


### PR DESCRIPTION
The test suite had **12 long-standing failures** (147/159 passing on `main`). This fixes all of them; 10 were stale tests, and 1 surfaced a **real validation gap** that's fixed in code.

## Real behavior fix
**`campaign-validation.ts`** — ACTIVE-stage validation only handled `ACTIVE`/`DISABLED`/`FAILED`. But `PAUSED` and `CANCELLED` are real `CampaignStatus` enum values (schema), and campaigns in those states **passed** pre-on-chain validation (`canProceed: true`). Added rules so PAUSED/CANCELLED campaigns fail ACTIVE-stage validation — matching what the tests assert and preventing operations on paused/cancelled campaigns from reaching the chain.

## Stale-test fixes
- **`auth.test.ts`** — `checkAuth` now confirms the session user exists via `getUser()`; the test only mocked `auth()`, so it hit a real Prisma client (`P2021`, no User table). Now mocks `./user`'s `getUser`.
- **`metadata.test.ts`** — env stubs leaked between tests: `afterEach` used `vi.restoreAllMocks()` (which doesn't clear stubbed env) and `beforeEach` reset from a **live `process.env` reference**, so `VERCEL_URL` set in test #1 bled into tests #2–5. Switched to `vi.unstubAllEnvs()` + explicit clean slate.
- **`get-qf-campaign-matching.test.ts`** — assertion used a stale error string; updated to the current `"Campaign N not found in round R distribution"`.

## Verification (in Docker)
- `pnpm test` — **159/159 passing** (was 147/159) ✅
- `tsc --noEmit` — clean ✅
- ESLint + Prettier (changed files) — clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Campaign validation now properly detects and blocks paused and cancelled campaigns from progression with appropriate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->